### PR TITLE
Move CausalCluster creation to CausalClusterStarter class

### DIFF
--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalCluster.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalCluster.java
@@ -18,18 +18,12 @@
  */
 package org.neo4j.junit.jupiter.causal_cluster;
 
-import static java.util.stream.Collectors.*;
-
 import java.net.URI;
 import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
 
 import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Neo4jContainer;
-import org.testcontainers.containers.Network;
 import org.testcontainers.containers.SocatContainer;
 
 /**
@@ -39,76 +33,23 @@ import org.testcontainers.containers.SocatContainer;
  */
 class CausalCluster implements CloseableResource {
 
-	private static final int DEFAULT_BOLT_PORT = 7687;
-
-	static CausalCluster start(Configuration configuration) {
-
-		final int numberOfCoreMembers = configuration.getNumberOfCoreMembers();
-
-		// Prepare one shared network for those containers
-		final Network network = Network.newNetwork();
-
-		// Setup a naming strategy and the initial discovery members
-		final String initialDiscoveryMembers = configuration.iterateCoreMembers()
-			.map(n -> String.format("%s:5000", n.getValue()))
-			.collect(joining(","));
-
-		// Prepare proxy to enter the cluster
-		final SocatContainer proxy = new SocatContainer().withNetwork(network);
-		configuration.iterateCoreMembers()
-			.forEach(member -> proxy.withTarget(DEFAULT_BOLT_PORT + member.getKey(), member.getValue(), DEFAULT_BOLT_PORT));
-
-		// Start the proxy so that the exposed ports are available and we can get the mapped ones
-		proxy.start();
-
-		final boolean is35 = configuration.getNeo4jVersion().startsWith("3.5");
-		// Build the cluster
-		final List<Neo4jContainer> cluster = configuration.iterateCoreMembers()
-			.map(member -> new Neo4jContainer<>(configuration.getImageName())
-				.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-				.withAdminPassword(configuration.getPassword())
-				.withNetwork(network)
-				.withNetworkAliases(member.getValue())
-				.withCreateContainerCmdModifier(cmd -> cmd.withHostName(member.getValue()))
-				.withNeo4jConfig("dbms.mode", "CORE")
-				.withNeo4jConfig("dbms.memory.pagecache.size", configuration.getPagecacheSize() + "M")
-				.withNeo4jConfig("dbms.memory.heap.initial_size", configuration.getInitialHeapSize() + "M")
-				.withNeo4jConfig(is35 ? "dbms.connectors.default_listen_address" : "dbms.default_listen_address", "0.0.0.0")
-				.withNeo4jConfig(is35 ? "dbms.connectors.default_advertised_address" : "dbms.default_advertised_address", member.getValue())
-				.withNeo4jConfig("dbms.connector.bolt.advertised_address", String.format("%s:%d", proxy.getContainerIpAddress(), proxy.getMappedPort(DEFAULT_BOLT_PORT + member.getKey())))
-				.withNeo4jConfig("causal_clustering.initial_discovery_members", initialDiscoveryMembers)
-				.withNeo4jConfig("causal_clustering.minimum_core_cluster_size_at_formation", Integer.toString(numberOfCoreMembers))
-				.withNeo4jConfig("causal_clustering.minimum_core_cluster_size_at_runtime", Integer.toString(numberOfCoreMembers))
-				.withStartupTimeout(configuration.getStartupTimeout()))
-			.collect(toList());
-
-		// Start all of them in parallel
-		final CountDownLatch latch = new CountDownLatch(numberOfCoreMembers);
-		cluster.forEach(instance -> CompletableFuture.runAsync(() -> {
-			instance.start();
-			latch.countDown();
-		}));
-
-		try {
-			latch.await();
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-		}
-
-		return new CausalCluster(proxy, cluster);
-	}
-
 	private final SocatContainer proxy;
 	private final Collection<Neo4jContainer> clusterMembers;
+	private final int boltPort;
 
-	CausalCluster(SocatContainer proxy, Collection<Neo4jContainer> clusterMembers) {
+	CausalCluster(SocatContainer boltProxy, int boltPort, Collection<Neo4jContainer> clusterMembers) {
 
-		this.proxy = proxy;
+		this.proxy = boltProxy;
 		this.clusterMembers = clusterMembers;
+		this.boltPort = boltPort;
 	}
 
 	public URI getURI() {
-		return URI.create(String.format("neo4j://%s:%d", proxy.getContainerIpAddress(), proxy.getMappedPort(DEFAULT_BOLT_PORT)));
+		return URI.create(String.format(
+			"neo4j://%s:%d",
+			proxy.getContainerIpAddress(),
+			proxy.getMappedPort(boltPort)
+		));
 	}
 
 	@Override

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalCluster.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalCluster.java
@@ -27,7 +27,7 @@ import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.containers.SocatContainer;
 
 /**
- * This takes care of all the containers started.
+ * This allows us to interact with the Neo4j Causal Cluster
  *
  * @author Michael J. Simons
  */

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalCluster.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalCluster.java
@@ -33,13 +33,13 @@ import org.testcontainers.containers.SocatContainer;
  */
 class CausalCluster implements CloseableResource {
 
-	private final SocatContainer proxy;
+	private final SocatContainer boltProxy;
 	private final Collection<Neo4jContainer> clusterMembers;
 	private final int boltPort;
 
 	CausalCluster(SocatContainer boltProxy, int boltPort, Collection<Neo4jContainer> clusterMembers) {
 
-		this.proxy = boltProxy;
+		this.boltProxy = boltProxy;
 		this.clusterMembers = clusterMembers;
 		this.boltPort = boltPort;
 	}
@@ -47,15 +47,15 @@ class CausalCluster implements CloseableResource {
 	public URI getURI() {
 		return URI.create(String.format(
 			"neo4j://%s:%d",
-			proxy.getContainerIpAddress(),
-			proxy.getMappedPort(boltPort)
+			boltProxy.getContainerIpAddress(),
+			boltProxy.getMappedPort(boltPort)
 		));
 	}
 
 	@Override
 	public void close() {
 
-		proxy.stop();
+		boltProxy.stop();
 		clusterMembers.forEach(GenericContainer::stop);
 	}
 }

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterExtension.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterExtension.java
@@ -111,7 +111,7 @@ class CausalClusterExtension implements BeforeAllCallback {
 			.getOrComputeIfAbsent(KEY_CONFIG, key -> DEFAULT_CONFIGURATION, Configuration.class);
 
 		URI uri = extensionContext.getStore(NAMESPACE)
-			.getOrComputeIfAbsent(KEY, key -> new CausalClusterStarter(configuration).start(), CausalCluster.class).getURI();
+			.getOrComputeIfAbsent(KEY, key -> new CausalClusterFactory(configuration).start(), CausalCluster.class).getURI();
 
 		return type == URI.class ? uri : uri.toString();
 	}

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterExtension.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterExtension.java
@@ -111,7 +111,7 @@ class CausalClusterExtension implements BeforeAllCallback {
 			.getOrComputeIfAbsent(KEY_CONFIG, key -> DEFAULT_CONFIGURATION, Configuration.class);
 
 		URI uri = extensionContext.getStore(NAMESPACE)
-			.getOrComputeIfAbsent(KEY, key -> CausalCluster.start(configuration), CausalCluster.class).getURI();
+			.getOrComputeIfAbsent(KEY, key -> new CausalClusterStarter(configuration).start(), CausalCluster.class).getURI();
 
 		return type == URI.class ? uri : uri.toString();
 	}

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterFactory.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterFactory.java
@@ -15,7 +15,7 @@ import org.testcontainers.containers.SocatContainer;
  *
  * @author Michael J. Simons
  */
-final class CausalClusterStarter {
+final class CausalClusterFactory {
 
 	private static final int DEFAULT_BOLT_PORT = 7687;
 
@@ -23,7 +23,7 @@ final class CausalClusterStarter {
 
 	private SocatContainer boltProxy;
 
-	CausalClusterStarter(Configuration configuration) {
+	CausalClusterFactory(Configuration configuration) {
 		this.configuration = configuration;
 	}
 

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterStarter.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterStarter.java
@@ -10,6 +10,11 @@ import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.SocatContainer;
 
+/**
+ * This takes care of all the containers started.
+ *
+ * @author Michael J. Simons
+ */
 public class CausalClusterStarter {
 
 	private static final int DEFAULT_BOLT_PORT = 7687;

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterStarter.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterStarter.java
@@ -15,7 +15,7 @@ import org.testcontainers.containers.SocatContainer;
  *
  * @author Michael J. Simons
  */
-public class CausalClusterStarter {
+final class CausalClusterStarter {
 
 	private static final int DEFAULT_BOLT_PORT = 7687;
 

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterStarter.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterStarter.java
@@ -23,7 +23,7 @@ final class CausalClusterStarter {
 
 	private SocatContainer boltProxy;
 
-	public CausalClusterStarter(Configuration configuration) {
+	CausalClusterStarter(Configuration configuration) {
 		this.configuration = configuration;
 	}
 

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterStarter.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterStarter.java
@@ -1,0 +1,90 @@
+package org.neo4j.junit.jupiter.causal_cluster;
+
+import static java.util.stream.Collectors.*;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.SocatContainer;
+
+public class CausalClusterStarter {
+
+	private static final int DEFAULT_BOLT_PORT = 7687;
+
+	private final Configuration configuration;
+
+	private SocatContainer boltProxy;
+
+	public CausalClusterStarter(Configuration configuration) {
+		this.configuration = configuration;
+	}
+
+	CausalCluster start() {
+
+		final int numberOfCoreMembers = configuration.getNumberOfCoreMembers();
+
+		// Prepare one shared network for those containers
+		final Network network = Network.newNetwork();
+
+		// Setup a naming strategy and the initial discovery members
+		final String initialDiscoveryMembers = configuration.iterateCoreMembers()
+			.map(n -> String.format("%s:5000", n.getValue()))
+			.collect(joining(","));
+
+		// Prepare proxy to enter the cluster
+		boltProxy = new SocatContainer().withNetwork(network);
+		configuration.iterateCoreMembers()
+			.forEach(
+				member -> boltProxy
+					.withTarget(DEFAULT_BOLT_PORT + member.getKey(), member.getValue(), DEFAULT_BOLT_PORT));
+
+		// Start the proxy so that the exposed ports are available and we can get the mapped ones
+		boltProxy.start();
+
+		final boolean is35 = configuration.getNeo4jVersion().startsWith("3.5");
+		// Build the cluster
+		final List<Neo4jContainer> cluster = configuration.iterateCoreMembers()
+			.map(member -> new Neo4jContainer<>(configuration.getImageName())
+				.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+				.withAdminPassword(configuration.getPassword())
+				.withNetwork(network)
+				.withNetworkAliases(member.getValue())
+				.withCreateContainerCmdModifier(cmd -> cmd.withHostName(member.getValue()))
+				.withNeo4jConfig("dbms.mode", "CORE")
+				.withNeo4jConfig("dbms.memory.pagecache.size", configuration.getPagecacheSize() + "M")
+				.withNeo4jConfig("dbms.memory.heap.initial_size", configuration.getInitialHeapSize() + "M")
+				.withNeo4jConfig(is35 ? "dbms.connectors.default_listen_address" : "dbms.default_listen_address",
+					"0.0.0.0")
+				.withNeo4jConfig(
+					is35 ? "dbms.connectors.default_advertised_address" : "dbms.default_advertised_address",
+					member.getValue())
+				.withNeo4jConfig("dbms.connector.bolt.advertised_address", String
+					.format("%s:%d", boltProxy.getContainerIpAddress(),
+						boltProxy.getMappedPort(DEFAULT_BOLT_PORT + member.getKey())))
+				.withNeo4jConfig("causal_clustering.initial_discovery_members", initialDiscoveryMembers)
+				.withNeo4jConfig("causal_clustering.minimum_core_cluster_size_at_formation",
+					Integer.toString(numberOfCoreMembers))
+				.withNeo4jConfig("causal_clustering.minimum_core_cluster_size_at_runtime",
+					Integer.toString(numberOfCoreMembers))
+				.withStartupTimeout(configuration.getStartupTimeout()))
+			.collect(toList());
+
+		// Start all of them in parallel
+		final CountDownLatch latch = new CountDownLatch(numberOfCoreMembers);
+		cluster.forEach(instance -> CompletableFuture.runAsync(() -> {
+			instance.start();
+			latch.countDown();
+		}));
+
+		try {
+			latch.await();
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+
+		return new CausalCluster(boltProxy, DEFAULT_BOLT_PORT, cluster);
+	}
+}


### PR DESCRIPTION
This is in anticipation of a whole load of changes that I have coming.

This change allows the code for the creation of the Neo4j Causal Cluster to be separate from the CausalCluster class that is created and will mean that the CausalCluster.java file doesn't become too big as both become creation and the created object become more sophisticated.