### PR TITLE
Make the number of read replicas configurable.

### DIFF
--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterExtension.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalClusterExtension.java
@@ -48,7 +48,7 @@ class CausalClusterExtension implements BeforeAllCallback {
 		.create(CausalClusterExtension.class);
 
 	static final String DEFAULT_NEO4J_VERSION = "4.0";
-	static final int DEFAULT_NUMBER_OF_CORE_MEMBERS = 3;
+	static final int DEFAULT_NUMBER_OF_CORE_SERVERS = 3;
 	static final int DEFAULT_NUMBER_OF_READ_REPLICAS = 0;
 	static final long DEFAULT_STARTUP_TIMEOUT_IN_MILLIS = 5 * 60 * 1_000;
 	static final String DEFAULT_PASSWORD = "password";
@@ -64,7 +64,7 @@ class CausalClusterExtension implements BeforeAllCallback {
 		List.class, Neo4jCluster.class };
 
 	private static final Configuration DEFAULT_CONFIGURATION = new Configuration(DEFAULT_NEO4J_VERSION,
-		DEFAULT_NUMBER_OF_CORE_MEMBERS,
+		DEFAULT_NUMBER_OF_CORE_SERVERS,
 		DEFAULT_NUMBER_OF_READ_REPLICAS, Duration.ofMillis(DEFAULT_STARTUP_TIMEOUT_IN_MILLIS), DEFAULT_PASSWORD,
 		DEFAULT_HEAP_SIZE_IN_MB, DEFAULT_PAGE_CACHE_IN_MB, null);
 
@@ -76,7 +76,8 @@ class CausalClusterExtension implements BeforeAllCallback {
 
 				final Configuration configuration = DEFAULT_CONFIGURATION
 					.withNeo4jVersion(annotation.neo4jVersion())
-					.withNumberOfCoreMembers(annotation.numberOfCoreMembers())
+					.withNumberOfCoreServers(annotation.numberOfCoreServers())
+					.withNumberOfReadReplicas(annotation.numberOfReadReplicas())
 					.withStartupTimeout(Duration.ofMillis(annotation.startupTimeOutInMillis()))
 					.withPassword(annotation.password())
 					.withCustomImageName(annotation.customImageName());

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/ClusterFactory.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/ClusterFactory.java
@@ -19,12 +19,18 @@
 package org.neo4j.junit.jupiter.causal_cluster;
 
 import java.net.URI;
+import java.util.AbstractMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import org.neo4j.junit.jupiter.causal_cluster.Neo4jServer.Role;
 import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.SocatContainer;
@@ -38,6 +44,8 @@ import org.testcontainers.containers.SocatContainer;
 final class ClusterFactory {
 
 	private static final int DEFAULT_BOLT_PORT = 7687;
+	public static final int MINIMUM_NUMBER_OF_CORE_SERVERS_REQUIRED = 3;
+	public static final int MINIMUM_NUMBER_OF_REPLICA_SERVERS_REQUIRED = 0;
 
 	private final Configuration configuration;
 
@@ -49,58 +57,56 @@ final class ClusterFactory {
 
 	Neo4jCluster createCluster() {
 
-		final int numberOfCoreMembers = configuration.getNumberOfCoreMembers();
+		final int numberOfCoreServers = configuration.getNumberOfCoreServers();
+		final int numberOfReplicaServers = configuration.getNumberOfReadReplicas();
+
+		// Have some sanity check on the number of servers
+		if (numberOfCoreServers < MINIMUM_NUMBER_OF_CORE_SERVERS_REQUIRED) {
+			throw new IllegalArgumentException("A cluster needs at least 3 core servers.");
+		}
+
+		if (numberOfReplicaServers < MINIMUM_NUMBER_OF_REPLICA_SERVERS_REQUIRED) {
+			throw new IllegalArgumentException("A cluster cannot have a negative number of read replicas.");
+		}
 
 		// Prepare one shared network for those containers
-		final Network network = Network.newNetwork();
+		final Network onNetwork = Network.newNetwork();
 
 		// Setup a naming strategy and the initial discovery members
-		final String initialDiscoveryMembers = configuration.iterateCoreMembers()
+		final String withInitialDiscoveryMembers = iterateCoreServers()
 			.map(n -> String.format("%s:5000", n.getValue()))
 			.collect(Collectors.joining(","));
 
 		// Prepare proxy to enter the cluster
-		boltProxy = new SocatContainer().withNetwork(network);
-		configuration.iterateCoreMembers()
-			.forEach(
-				member -> boltProxy
-					.withTarget(DEFAULT_BOLT_PORT + member.getKey(), member.getValue(), DEFAULT_BOLT_PORT));
+		boltProxy = new SocatContainer().withNetwork(onNetwork);
+		iterateCoreServers().forEach(member -> boltProxy
+			.withTarget(member.getKey(), member.getValue(), DEFAULT_BOLT_PORT));
+		iterateReplicaServers().forEach(member -> boltProxy
+			.withTarget(member.getKey(), member.getValue(), DEFAULT_BOLT_PORT));
 
 		// Start the proxy so that the exposed ports are available and we can get the mapped ones
 		boltProxy.start();
 
-		final boolean is35 = configuration.getNeo4jVersion().startsWith("3.5");
-		// Build the cluster
-		final List<Neo4jContainer<?>> cluster = configuration.iterateCoreMembers()
-			.map(member -> new Neo4jContainer<>(configuration.getImageName())
-				.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-				.withAdminPassword(configuration.getPassword())
-				.withNetwork(network)
-				.withNetworkAliases(member.getValue())
-				.withCreateContainerCmdModifier(cmd -> cmd.withHostName(member.getValue()))
-				.withNeo4jConfig("dbms.mode", "CORE")
-				.withNeo4jConfig("dbms.memory.pagecache.size", configuration.getPagecacheSize() + "M")
-				.withNeo4jConfig("dbms.memory.heap.initial_size", configuration.getInitialHeapSize() + "M")
-				.withNeo4jConfig(is35 ? "dbms.connectors.default_listen_address" : "dbms.default_listen_address",
-					"0.0.0.0")
-				.withNeo4jConfig(
-					is35 ? "dbms.connectors.default_advertised_address" : "dbms.default_advertised_address",
-					member.getValue())
-				.withNeo4jConfig("dbms.connector.bolt.advertised_address", String
-					.format("%s:%d", boltProxy.getContainerIpAddress(),
-						boltProxy.getMappedPort(DEFAULT_BOLT_PORT + member.getKey())))
-				.withNeo4jConfig("causal_clustering.initial_discovery_members", initialDiscoveryMembers)
-				.withNeo4jConfig("causal_clustering.minimum_core_cluster_size_at_formation",
-					Integer.toString(numberOfCoreMembers))
-				.withNeo4jConfig("causal_clustering.minimum_core_cluster_size_at_runtime",
-					Integer.toString(numberOfCoreMembers))
-				.withStartupTimeout(configuration.getStartupTimeout()))
+		// First configure the core server container
+		final List<DefaultNeo4jServer> coreServers = iterateCoreServers()
+			.map(createCoreServer(onNetwork, withInitialDiscoveryMembers))
 			.collect(Collectors.toList());
+		startInParallel(coreServers);
 
-		// Start all of them in parallel
-		final CountDownLatch latch = new CountDownLatch(numberOfCoreMembers);
-		cluster.forEach(instance -> CompletableFuture.runAsync(() -> {
-			instance.start();
+		// Then the replicas configure the core server container
+		final List<DefaultNeo4jServer> readReplicaServers = iterateReplicaServers()
+			.map(createReadReplica(onNetwork, withInitialDiscoveryMembers))
+			.collect(Collectors.toList());
+		startInParallel(readReplicaServers);
+
+		return new DefaultCluster(boltProxy, coreServers, readReplicaServers);
+	}
+
+	private void startInParallel(List<DefaultNeo4jServer> servers) {
+
+		final CountDownLatch latch = new CountDownLatch(servers.size());
+		servers.forEach(instance -> CompletableFuture.runAsync(() -> {
+			instance.unwrap().start();
 			latch.countDown();
 		}));
 
@@ -109,12 +115,103 @@ final class ClusterFactory {
 		} catch (InterruptedException e) {
 			e.printStackTrace();
 		}
+	}
 
-		List<DefaultNeo4jServer> neo4jCores = IntStream.range(0, cluster.size())
-			.mapToObj(idx -> new DefaultNeo4jServer(cluster.get(idx), getNeo4jUri(DEFAULT_BOLT_PORT + idx)))
-			.collect(Collectors.toList());
+	private Stream<Map.Entry<Integer, String>> iterateCoreServers() {
+		final IntFunction<String> generateInstanceName = i -> String.format("neo4j%d", i);
 
-		return new DefaultCluster(boltProxy, neo4jCores);
+		return IntStream.rangeClosed(1, this.configuration.getNumberOfCoreServers())
+			.mapToObj(i -> new AbstractMap.SimpleEntry<>(DEFAULT_BOLT_PORT + i - 1, generateInstanceName.apply(i)));
+	}
+
+	private Stream<Map.Entry<Integer, String>> iterateReplicaServers() {
+		final IntFunction<String> generateInstanceName = i -> String.format("replica%d", i);
+
+		return IntStream.rangeClosed(1, this.configuration.getNumberOfReadReplicas())
+			.mapToObj(
+				i -> new AbstractMap.SimpleEntry<>(DEFAULT_BOLT_PORT + configuration.getNumberOfCoreServers() + i - 1,
+					generateInstanceName.apply(i)));
+	}
+
+	private Function<Map.Entry<Integer, String>, DefaultNeo4jServer> createCoreServer(
+		final Network network,
+		final String initialDiscoveryMembers) {
+
+		return (portAndAlias) -> {
+			Neo4jContainer<?> container = configureContainerForCoreServer(portAndAlias, network,
+				initialDiscoveryMembers);
+			return new DefaultNeo4jServer(container, getNeo4jUri(portAndAlias.getKey()), Role.CORE_SERVER);
+		};
+	}
+
+	private Function<Map.Entry<Integer, String>, DefaultNeo4jServer> createReadReplica(
+		final Network network,
+		final String initialDiscoveryMembers) {
+
+		return (portAndAlias) -> {
+			Neo4jContainer<?> container = configureContainerForReplicaServerOn(portAndAlias, network,
+				initialDiscoveryMembers);
+			return new DefaultNeo4jServer(container, getNeo4jUri(portAndAlias.getKey()), Role.REPLICA_SERVER);
+		};
+	}
+
+	private Neo4jContainer<?> configureContainerForCoreServer(
+		final Map.Entry<Integer, String> portAndAlias,
+		final Network network,
+		final String initialDiscoveryMembers
+	) {
+
+		String numberOfCoreServers = Integer.toString(configuration.getNumberOfCoreServers());
+
+		return newContainerWithCommonConfig(portAndAlias, network)
+			.withNeo4jConfig("dbms.mode", "CORE")
+			.withNeo4jConfig("causal_clustering.initial_discovery_members", initialDiscoveryMembers)
+			.withNeo4jConfig("causal_clustering.minimum_core_cluster_size_at_formation", numberOfCoreServers)
+			.withNeo4jConfig("causal_clustering.minimum_core_cluster_size_at_runtime", numberOfCoreServers)
+			.withStartupTimeout(configuration.getStartupTimeout());
+	}
+
+	private Neo4jContainer<?> configureContainerForReplicaServerOn(
+		Map.Entry<Integer, String> portAndAlias,
+		final Network network,
+		final String initialDiscoveryMembers
+	) {
+		Neo4jContainer<?> readReplicaContainer = newContainerWithCommonConfig(portAndAlias, network)
+			.withNeo4jConfig("dbms.mode", "READ_REPLICA")
+			.withNeo4jConfig("causal_clustering.initial_discovery_members", initialDiscoveryMembers)
+			.withStartupTimeout(configuration.getStartupTimeout());
+
+		// See https://neo4j.com/docs/operations-manual/4.1/clustering/deploy/#causal-clustering-add-read-replica
+		// But I assume a bug in the docs, needs to be confirmed though.
+		if (configuration.is41()) {
+			readReplicaContainer = readReplicaContainer
+				.withNeo4jConfig("causal_clustering.discovery_members", initialDiscoveryMembers);
+		}
+		return readReplicaContainer;
+	}
+
+	private Neo4jContainer<?> newContainerWithCommonConfig(Map.Entry<Integer, String> portAndAlias, Network network) {
+
+		boolean is35 = configuration.is35();
+		String alias = portAndAlias.getValue();
+
+		String advertisedAddress = String.format("%s:%d",
+			boltProxy.getContainerIpAddress(),
+			boltProxy.getMappedPort(portAndAlias.getKey())
+		);
+
+		return new Neo4jContainer<>(configuration.getImageName())
+			.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+			.withAdminPassword(configuration.getPassword())
+			.withNetwork(network)
+			.withNetworkAliases(alias)
+			.withCreateContainerCmdModifier(cmd -> cmd.withHostName(alias))
+			.withNeo4jConfig("dbms.memory.pagecache.size", configuration.getPagecacheSize() + "M")
+			.withNeo4jConfig("dbms.memory.heap.initial_size", configuration.getInitialHeapSize() + "M")
+			.withNeo4jConfig(is35 ? "dbms.connectors.default_listen_address" : "dbms.default_listen_address", "0.0.0.0")
+			.withNeo4jConfig(is35 ? "dbms.connectors.default_advertised_address" : "dbms.default_advertised_address",
+				alias)
+			.withNeo4jConfig("dbms.connector.bolt.advertised_address", advertisedAddress);
 	}
 
 	private URI getNeo4jUri(int boltPort) {

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/ClusterFactory.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/ClusterFactory.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.neo4j.junit.jupiter.causal_cluster.Neo4jServer.Role;
+import org.neo4j.junit.jupiter.causal_cluster.Neo4jServer.Type;
 import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.SocatContainer;
@@ -140,7 +140,7 @@ final class ClusterFactory {
 		return (portAndAlias) -> {
 			Neo4jContainer<?> container = configureContainerForCoreServer(portAndAlias, network,
 				initialDiscoveryMembers);
-			return new DefaultNeo4jServer(container, getNeo4jUri(portAndAlias.getKey()), Role.CORE_SERVER);
+			return new DefaultNeo4jServer(container, getNeo4jUri(portAndAlias.getKey()), Type.CORE_SERVER);
 		};
 	}
 
@@ -151,7 +151,7 @@ final class ClusterFactory {
 		return (portAndAlias) -> {
 			Neo4jContainer<?> container = configureContainerForReplicaServerOn(portAndAlias, network,
 				initialDiscoveryMembers);
-			return new DefaultNeo4jServer(container, getNeo4jUri(portAndAlias.getKey()), Role.REPLICA_SERVER);
+			return new DefaultNeo4jServer(container, getNeo4jUri(portAndAlias.getKey()), Neo4jServer.Type.REPLICA_SERVER);
 		};
 	}
 

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Configuration.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Configuration.java
@@ -20,12 +20,7 @@ package org.neo4j.junit.jupiter.causal_cluster;
 
 import java.io.Serializable;
 import java.time.Duration;
-import java.util.AbstractMap;
-import java.util.Map;
 import java.util.Optional;
-import java.util.function.IntFunction;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 /**
  * The clusters configuration.
@@ -36,7 +31,7 @@ final class Configuration implements Serializable {
 
 	private final String neo4jVersion;
 
-	private final int numberOfCoreMembers;
+	private final int numberOfCoreServers;
 
 	private final int numberOfReadReplicas;
 
@@ -53,27 +48,16 @@ final class Configuration implements Serializable {
 	 */
 	private final String customImageName;
 
-	Configuration(String neo4jVersion, int numberOfCoreMembers, int numberOfReadReplicas,
+	Configuration(String neo4jVersion, int numberOfCoreServers, int numberOfReadReplicas,
 		Duration startupTimeout, String password, int initialHeapSize, int pagecacheSize, String customImageName) {
 		this.neo4jVersion = neo4jVersion;
-		this.numberOfCoreMembers = numberOfCoreMembers;
+		this.numberOfCoreServers = numberOfCoreServers;
 		this.numberOfReadReplicas = numberOfReadReplicas;
 		this.startupTimeout = startupTimeout;
 		this.password = password;
 		this.initialHeapSize = initialHeapSize;
 		this.pagecacheSize = pagecacheSize;
 		this.customImageName = customImageName;
-	}
-
-	/**
-	 * Get the core index and hostname for all configured cores
-	 * @return A stream mapping a core index (integer) -> hostname (String)
-	 */
-	Stream<Map.Entry<Integer, String>> iterateCoreMembers() {
-		final IntFunction<String> generateInstanceName = i -> String.format("neo4j%d", i);
-
-		return IntStream.rangeClosed(1, numberOfCoreMembers)
-			.mapToObj(i -> new AbstractMap.SimpleEntry<>(i - 1, generateInstanceName.apply(i)));
 	}
 
 	String getImageName() {
@@ -85,8 +69,8 @@ final class Configuration implements Serializable {
 		return this.neo4jVersion;
 	}
 
-	public int getNumberOfCoreMembers() {
-		return this.numberOfCoreMembers;
+	public int getNumberOfCoreServers() {
+		return this.numberOfCoreServers;
 	}
 
 	public int getNumberOfReadReplicas() {
@@ -113,65 +97,76 @@ final class Configuration implements Serializable {
 		return this.customImageName;
 	}
 
+	/**
+	 * @return true if this configuration starts a Neo4j 3.5 cluster.
+	 */
+	boolean is35() {
+		return getNeo4jVersion().startsWith("3.5");
+	}
+
+	boolean is41() {
+		return getNeo4jVersion().startsWith("4.1");
+	}
+
 	public Configuration withNeo4jVersion(String newNeo4jVersion) {
 		return this.neo4jVersion == newNeo4jVersion ?
 			this :
-			new Configuration(newNeo4jVersion, this.numberOfCoreMembers, this.numberOfReadReplicas, this.startupTimeout,
+			new Configuration(newNeo4jVersion, this.numberOfCoreServers, this.numberOfReadReplicas, this.startupTimeout,
 				this.password, this.initialHeapSize, this.pagecacheSize, this.customImageName);
 	}
 
-	public Configuration withNumberOfCoreMembers(int newNumberOfCoreMembers) {
-		return this.numberOfCoreMembers == newNumberOfCoreMembers ?
+	public Configuration withNumberOfCoreServers(int newNumberOfCoreServers) {
+		return this.numberOfCoreServers == newNumberOfCoreServers ?
 			this :
-			new Configuration(this.neo4jVersion, newNumberOfCoreMembers, this.numberOfReadReplicas, this.startupTimeout,
+			new Configuration(this.neo4jVersion, newNumberOfCoreServers, this.numberOfReadReplicas, this.startupTimeout,
 				this.password, this.initialHeapSize, this.pagecacheSize, this.customImageName);
 	}
 
 	public Configuration withNumberOfReadReplicas(int newNumberOfReadReplicas) {
 		return this.numberOfReadReplicas == newNumberOfReadReplicas ?
 			this :
-			new Configuration(this.neo4jVersion, this.numberOfCoreMembers, newNumberOfReadReplicas, this.startupTimeout,
+			new Configuration(this.neo4jVersion, this.numberOfCoreServers, newNumberOfReadReplicas, this.startupTimeout,
 				this.password, this.initialHeapSize, this.pagecacheSize, this.customImageName);
 	}
 
 	public Configuration withStartupTimeout(Duration newStartupTimeout) {
 		return this.startupTimeout == newStartupTimeout ?
 			this :
-			new Configuration(this.neo4jVersion, this.numberOfCoreMembers, this.numberOfReadReplicas, newStartupTimeout,
+			new Configuration(this.neo4jVersion, this.numberOfCoreServers, this.numberOfReadReplicas, newStartupTimeout,
 				this.password, this.initialHeapSize, this.pagecacheSize, this.customImageName);
 	}
 
 	public Configuration withPassword(String newPassword) {
 		return this.password == newPassword ?
 			this :
-			new Configuration(this.neo4jVersion, this.numberOfCoreMembers, this.numberOfReadReplicas,
+			new Configuration(this.neo4jVersion, this.numberOfCoreServers, this.numberOfReadReplicas,
 				this.startupTimeout, newPassword, this.initialHeapSize, this.pagecacheSize, this.customImageName);
 	}
 
 	public Configuration withInitialHeapSize(int newInitialHeapSize) {
 		return this.initialHeapSize == newInitialHeapSize ?
 			this :
-			new Configuration(this.neo4jVersion, this.numberOfCoreMembers, this.numberOfReadReplicas,
+			new Configuration(this.neo4jVersion, this.numberOfCoreServers, this.numberOfReadReplicas,
 				this.startupTimeout, this.password, newInitialHeapSize, this.pagecacheSize, this.customImageName);
 	}
 
 	public Configuration withPagecacheSize(int newPagecacheSize) {
 		return this.pagecacheSize == newPagecacheSize ?
 			this :
-			new Configuration(this.neo4jVersion, this.numberOfCoreMembers, this.numberOfReadReplicas,
+			new Configuration(this.neo4jVersion, this.numberOfCoreServers, this.numberOfReadReplicas,
 				this.startupTimeout, this.password, this.initialHeapSize, newPagecacheSize, this.customImageName);
 	}
 
 	public Configuration withCustomImageName(String newCustomImageName) {
 		return this.customImageName == newCustomImageName ?
 			this :
-			new Configuration(this.neo4jVersion, this.numberOfCoreMembers, this.numberOfReadReplicas,
+			new Configuration(this.neo4jVersion, this.numberOfCoreServers, this.numberOfReadReplicas,
 				this.startupTimeout, this.password, this.initialHeapSize, this.pagecacheSize, newCustomImageName);
 	}
 
 	public String toString() {
 		return "Configuration(neo4jVersion=" + this.getNeo4jVersion() + ", numberOfCoreMembers=" + this
-			.getNumberOfCoreMembers() + ", numberOfReadReplicas=" + this.getNumberOfReadReplicas() + ", startupTimeout="
+			.getNumberOfCoreServers() + ", numberOfReadReplicas=" + this.getNumberOfReadReplicas() + ", startupTimeout="
 			+ this.getStartupTimeout() + ", password=" + this.getPassword() + ", initialHeapSize=" + this
 			.getInitialHeapSize() + ", pagecacheSize=" + this.getPagecacheSize() + ", customImageName=" + this
 			.getCustomImageName() + ")";

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultCluster.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultCluster.java
@@ -18,7 +18,6 @@
  */
 package org.neo4j.junit.jupiter.causal_cluster;
 
-import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -75,14 +74,6 @@ final class DefaultCluster implements Neo4jCluster, CloseableResource {
 		this.clusterServers = new ArrayList<>(clusterServers.size() + readReplicaServers.size());
 		this.clusterServers.addAll(clusterServers);
 		this.clusterServers.addAll(readReplicaServers);
-	}
-
-	@Override
-	public URI getURI() {
-
-		// Choose a random bolt port from the available ports
-		DefaultNeo4jServer server = clusterServers.get(ThreadLocalRandom.current().nextInt(0, clusterServers.size()));
-		return server.getURI();
 	}
 
 	@Override

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultCluster.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultCluster.java
@@ -21,6 +21,7 @@ package org.neo4j.junit.jupiter.causal_cluster;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -62,12 +63,23 @@ final class DefaultCluster implements Neo4jCluster, CloseableResource {
 
 	DefaultCluster(SocatContainer boltProxy, List<DefaultNeo4jServer> clusterServers) {
 
+		this(boltProxy, clusterServers, Collections.emptyList());
+	}
+
+	DefaultCluster(
+		SocatContainer boltProxy, List<DefaultNeo4jServer> clusterServers,
+		List<DefaultNeo4jServer> readReplicaServers
+	) {
+
 		this.boltProxy = boltProxy;
-		this.clusterServers = clusterServers;
+		this.clusterServers = new ArrayList<>(clusterServers.size() + readReplicaServers.size());
+		this.clusterServers.addAll(clusterServers);
+		this.clusterServers.addAll(readReplicaServers);
 	}
 
 	@Override
 	public URI getURI() {
+
 		// Choose a random bolt port from the available ports
 		DefaultNeo4jServer server = clusterServers.get(ThreadLocalRandom.current().nextInt(0, clusterServers.size()));
 		return server.getURI();

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultNeo4jServer.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultNeo4jServer.java
@@ -46,11 +46,11 @@ import org.testcontainers.containers.Neo4jContainer;
  */
 final class DefaultNeo4jServer implements Neo4jServer, AutoCloseable {
 
-	private final static ScriptEngine scriptEngine;
+	private final static ScriptEngine SCRIPT_ENGINE;
 
 	static {
 		ScriptEngineManager sem = new ScriptEngineManager();
-		scriptEngine = sem.getEngineByName("javascript");
+		SCRIPT_ENGINE = sem.getEngineByName("javascript");
 	}
 
 	private enum LogFile {
@@ -229,10 +229,10 @@ final class DefaultNeo4jServer implements Neo4jServer, AutoCloseable {
 			+ "} else {\n"
 			+ "    response.results[0].data[0].row.join(\",\");\n"
 			+ "}";
-		Bindings parameter = scriptEngine.createBindings();
+		Bindings parameter = SCRIPT_ENGINE.createBindings();
 		parameter.put("response", response);
 		try {
-			return (String) scriptEngine.eval(scriptTemplate, parameter);
+			return (String) SCRIPT_ENGINE.eval(scriptTemplate, parameter);
 		} catch (ScriptException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultNeo4jServer.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultNeo4jServer.java
@@ -52,10 +52,15 @@ final class DefaultNeo4jServer implements Neo4jServer, AutoCloseable {
 	 * The external URI under which this server is reachable, not to be confused with the internal URI returned by {@link Neo4jContainer#getBoltUrl()}.
 	 */
 	private final URI externalURI;
+	/**
+	 * The type of this server.
+	 */
+	private final Role role;
 
-	DefaultNeo4jServer(Neo4jContainer<?> container, URI externalURI) {
+	DefaultNeo4jServer(Neo4jContainer<?> container, URI externalURI, Role role) {
 		this.container = container;
 		this.externalURI = externalURI;
+		this.role = role;
 	}
 
 	@Override
@@ -130,7 +135,21 @@ final class DefaultNeo4jServer implements Neo4jServer, AutoCloseable {
 		return container.isRunning();
 	}
 
+	@Override
+	public Role getRole() {
+		return role;
+	}
+
 	Neo4jContainer<?> unwrap() {
 		return container;
+	}
+
+	@Override
+	public String toString() {
+		return "DefaultNeo4jServer{" +
+			"container=" + container.getContainerId() +
+			", externalURI=" + externalURI +
+			", type=" + role +
+			'}';
 	}
 }

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultNeo4jServer.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultNeo4jServer.java
@@ -55,12 +55,12 @@ final class DefaultNeo4jServer implements Neo4jServer, AutoCloseable {
 	/**
 	 * The type of this server.
 	 */
-	private final Role role;
+	private final Type type;
 
-	DefaultNeo4jServer(Neo4jContainer<?> container, URI externalURI, Role role) {
+	DefaultNeo4jServer(Neo4jContainer<?> container, URI externalURI, Type type) {
 		this.container = container;
 		this.externalURI = externalURI;
-		this.role = role;
+		this.type = type;
 	}
 
 	@Override
@@ -136,8 +136,8 @@ final class DefaultNeo4jServer implements Neo4jServer, AutoCloseable {
 	}
 
 	@Override
-	public Role getRole() {
-		return role;
+	public Type getType() {
+		return type;
 	}
 
 	Neo4jContainer<?> unwrap() {
@@ -149,7 +149,7 @@ final class DefaultNeo4jServer implements Neo4jServer, AutoCloseable {
 		return "DefaultNeo4jServer{" +
 			"container=" + container.getContainerId() +
 			", externalURI=" + externalURI +
-			", type=" + role +
+			", type=" + type +
 			'}';
 	}
 }

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultNeo4jServer.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultNeo4jServer.java
@@ -18,25 +18,12 @@
  */
 package org.neo4j.junit.jupiter.causal_cluster;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Base64;
-import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
-
-import javax.script.Bindings;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
 
 import org.testcontainers.containers.Neo4jContainer;
 
@@ -45,13 +32,6 @@ import org.testcontainers.containers.Neo4jContainer;
  * @author Michael J. Simons
  */
 final class DefaultNeo4jServer implements Neo4jServer, AutoCloseable {
-
-	private final static ScriptEngine SCRIPT_ENGINE;
-
-	static {
-		ScriptEngineManager sem = new ScriptEngineManager();
-		SCRIPT_ENGINE = sem.getEngineByName("javascript");
-	}
 
 	private enum LogFile {
 		DEBUG("debug.log"),
@@ -168,74 +148,6 @@ final class DefaultNeo4jServer implements Neo4jServer, AutoCloseable {
 	@Override
 	public Type getType() {
 		return type;
-	}
-
-	@Override
-	public List<String> getRolesFor(String database) {
-
-		CharSequence response = callDbmsClusterRole(this.container.getHttpUrl() + "/db/system/tx/commit", authToken,
-			database);
-		String result = evaluateResponse(response);
-
-		if (result.startsWith("Error: ")) {
-			throw new RuntimeException(result.substring(result.indexOf(" ") + 1));
-		} else {
-			return Arrays.stream(result.split(",")).map(String::trim).collect(Collectors.toList());
-		}
-	}
-
-	private static CharSequence callDbmsClusterRole(String txEndpoint, String authToken, String database) {
-
-		try {
-			HttpURLConnection con = (HttpURLConnection) new URL(txEndpoint).openConnection();
-
-			con.setDoOutput(true);
-			con.setRequestProperty("Content-Type", "application/json; charset=utf-8");
-			con.setRequestProperty("Accept", "application/json");
-			con.setRequestProperty("Authorization", authToken);
-
-			try (OutputStream os = con.getOutputStream()) {
-				String payload =
-					"{\"statements\":[{\"statement\":\"CALL dbms.cluster.role($databaseName)\",\"parameters\":{\"databaseName\":\""
-						+ database + "\"}}]}";
-				byte[] input = payload.getBytes(StandardCharsets.UTF_8);
-				os.write(input, 0, input.length);
-				os.flush();
-			}
-
-			con.connect();
-			int status = con.getResponseCode();
-			if (status != 200) {
-				throw new RuntimeException(status + ": " + con.getResponseMessage());
-			}
-
-			try (BufferedReader reader = new BufferedReader(
-				new InputStreamReader(con.getInputStream(), StandardCharsets.UTF_8))) {
-				return reader.lines().collect(Collectors.joining());
-			}
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	private static String evaluateResponse(CharSequence response) {
-
-		String scriptTemplate = "var response = JSON.parse(response);\n"
-			+ "if(response.errors.length > 0) {\n"
-			+ "    function x(error) {\n"
-			+ "        return error.message + \" (\" + error.code + \")\"\n"
-			+ "    }\n"
-			+ "    \"Error: \" + response.errors.map(x).join(\",\");"
-			+ "} else {\n"
-			+ "    response.results[0].data[0].row.join(\",\");\n"
-			+ "}";
-		Bindings parameter = SCRIPT_ENGINE.createBindings();
-		parameter.put("response", response);
-		try {
-			return (String) SCRIPT_ENGINE.eval(scriptTemplate, parameter);
-		} catch (ScriptException e) {
-			throw new RuntimeException(e);
-		}
 	}
 
 	Neo4jContainer<?> unwrap() {

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/NeedsCausalCluster.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/NeedsCausalCluster.java
@@ -38,7 +38,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Inherited
 @ExtendWith(CausalClusterExtension.class)
 public @interface NeedsCausalCluster {
-	int numberOfCoreMembers() default CausalClusterExtension.DEFAULT_NUMBER_OF_CORE_MEMBERS;
+
+	/**
+	 * @return The number of core servers. A minimum number of 3 is required.
+	 */
+	int numberOfCoreServers() default CausalClusterExtension.DEFAULT_NUMBER_OF_CORE_SERVERS;
+
+	/**
+	 * @return The number of read replicas. A minimum number of 0 is required.
+	 */
+	int numberOfReadReplicas() default CausalClusterExtension.DEFAULT_NUMBER_OF_READ_REPLICAS;
 
 	/**
 	 * @return A valid Neo4j version number.

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Neo4jServer.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Neo4jServer.java
@@ -19,6 +19,7 @@
 package org.neo4j.junit.jupiter.causal_cluster;
 
 import java.net.URI;
+import java.util.List;
 
 /**
  * This is a Neo4j instance that is a part of causal cluster, with {@literal Neo4jServer} being used equally for Core and
@@ -78,4 +79,10 @@ public interface Neo4jServer {
 	 * @return The type of this server.
 	 */
 	Type getType();
+
+	/**
+	 * @param database The database for which the roles should be retrieved.
+	 * @return The roles that this server has for the database in question.
+	 */
+	List<String> getRolesFor(String database);
 }

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Neo4jServer.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Neo4jServer.java
@@ -33,7 +33,7 @@ public interface Neo4jServer {
 	/**
 	 * Server can either be a core or replica server.
 	 */
-	enum Role {
+	enum Type {
 		CORE_SERVER,
 		REPLICA_SERVER,
 		UNKNOWN
@@ -77,5 +77,5 @@ public interface Neo4jServer {
 	/**
 	 * @return The type of this server.
 	 */
-	Role getRole();
+	Type getType();
 }

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Neo4jServer.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Neo4jServer.java
@@ -31,6 +31,15 @@ import java.net.URI;
 public interface Neo4jServer {
 
 	/**
+	 * Server can either be a core or replica server.
+	 */
+	enum Role {
+		CORE_SERVER,
+		REPLICA_SERVER,
+		UNKNOWN
+	}
+
+	/**
 	 * @return The complete Neo4j debug log.
 	 */
 	String getDebugLog();
@@ -55,10 +64,18 @@ public interface Neo4jServer {
 	 */
 	URI getURI();
 
+	/**
+	 * @return The URI into this server but using the {@code bolt} instead of the {@code neo4j} protocol.
+	 */
 	URI getDirectBoltUri();
 
 	/**
 	 * @return True if the underlying container is running.
 	 */
 	boolean isContainerRunning();
+
+	/**
+	 * @return The type of this server.
+	 */
+	Role getRole();
 }

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Neo4jServer.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Neo4jServer.java
@@ -19,7 +19,6 @@
 package org.neo4j.junit.jupiter.causal_cluster;
 
 import java.net.URI;
-import java.util.List;
 
 /**
  * This is a Neo4j instance that is a part of causal cluster, with {@literal Neo4jServer} being used equally for Core and
@@ -36,8 +35,7 @@ public interface Neo4jServer {
 	 */
 	enum Type {
 		CORE_SERVER,
-		REPLICA_SERVER,
-		UNKNOWN
+		REPLICA_SERVER
 	}
 
 	/**
@@ -79,10 +77,4 @@ public interface Neo4jServer {
 	 * @return The type of this server.
 	 */
 	Type getType();
-
-	/**
-	 * @param database The database for which the roles should be retrieved.
-	 * @return The roles that this server has for the database in question.
-	 */
-	List<String> getRolesFor(String database);
 }

--- a/src/test/java/org/neo4j/junit/jupiter/causal_cluster/AllAnnotationsAppliedTest.java
+++ b/src/test/java/org/neo4j/junit/jupiter/causal_cluster/AllAnnotationsAppliedTest.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.ReflectionUtils;
-import org.neo4j.junit.jupiter.causal_cluster.Neo4jServer.Type;
 import org.testcontainers.containers.Neo4jContainer;
 
 @NeedsCausalCluster

--- a/src/test/java/org/neo4j/junit/jupiter/causal_cluster/AllAnnotationsAppliedTest.java
+++ b/src/test/java/org/neo4j/junit/jupiter/causal_cluster/AllAnnotationsAppliedTest.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.ReflectionUtils;
-import org.neo4j.junit.jupiter.causal_cluster.Neo4jServer.Role;
+import org.neo4j.junit.jupiter.causal_cluster.Neo4jServer.Type;
 import org.testcontainers.containers.Neo4jContainer;
 
 @NeedsCausalCluster
@@ -99,7 +99,7 @@ class AllAnnotationsAppliedTest {
 		for (Neo4jServer server : allServers) {
 
 			DefaultNeo4jServer newServer = new DefaultNeo4jServer(
-				(Neo4jContainer<?>) field.get(server), new URI(server.getURI().toString()), Role.UNKNOWN);
+				(Neo4jContainer<?>) field.get(server), new URI(server.getURI().toString()), Type.UNKNOWN);
 
 			assertThat(newServer.hashCode()).isEqualTo(server.hashCode());
 			assertThat(newServer).isEqualTo(server);

--- a/src/test/java/org/neo4j/junit/jupiter/causal_cluster/AllAnnotationsAppliedTest.java
+++ b/src/test/java/org/neo4j/junit/jupiter/causal_cluster/AllAnnotationsAppliedTest.java
@@ -99,7 +99,7 @@ class AllAnnotationsAppliedTest {
 		for (Neo4jServer server : allServers) {
 
 			DefaultNeo4jServer newServer = new DefaultNeo4jServer(
-				(Neo4jContainer<?>) field.get(server), new URI(server.getURI().toString()), Type.UNKNOWN);
+				(Neo4jContainer<?>) field.get(server), new URI(server.getURI().toString()), server.getType());
 
 			assertThat(newServer.hashCode()).isEqualTo(server.hashCode());
 			assertThat(newServer).isEqualTo(server);

--- a/src/test/java/org/neo4j/junit/jupiter/causal_cluster/AllAnnotationsAppliedTest.java
+++ b/src/test/java/org/neo4j/junit/jupiter/causal_cluster/AllAnnotationsAppliedTest.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.neo4j.junit.jupiter.causal_cluster.Neo4jServer.Role;
 import org.testcontainers.containers.Neo4jContainer;
 
 @NeedsCausalCluster
@@ -87,7 +88,7 @@ class AllAnnotationsAppliedTest {
 	void serverComparisonTest() throws URISyntaxException, IllegalAccessException {
 		// Get the container. 🤠
 		Field field = ReflectionUtils
-			.findFields(DefaultNeo4jServer.class, f -> "container".equals(f.getName()),
+			.findFields(DefaultNeo4jServer.class, f -> "container" .equals(f.getName()),
 				ReflectionUtils.HierarchyTraversalMode.TOP_DOWN).get(0);
 		field.setAccessible(true);
 
@@ -98,7 +99,7 @@ class AllAnnotationsAppliedTest {
 		for (Neo4jServer server : allServers) {
 
 			DefaultNeo4jServer newServer = new DefaultNeo4jServer(
-				(Neo4jContainer<?>) field.get(server), new URI(server.getURI().toString()));
+				(Neo4jContainer<?>) field.get(server), new URI(server.getURI().toString()), Role.UNKNOWN);
 
 			assertThat(newServer.hashCode()).isEqualTo(server.hashCode());
 			assertThat(newServer).isEqualTo(server);
@@ -110,6 +111,7 @@ class AllAnnotationsAppliedTest {
 
 	@Test
 	void typesTest() {
+
 		// Runtime annotation processing & reflection has the potential to let you assign any class to a field
 		// (particularly with generics). So here we explicitly check the types at runtime
 

--- a/src/test/java/org/neo4j/junit/jupiter/causal_cluster/CoreAndReadReplicasTest.java
+++ b/src/test/java/org/neo4j/junit/jupiter/causal_cluster/CoreAndReadReplicasTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.junit.jupiter.causal_cluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Logging;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Values;
+import org.neo4j.junit.jupiter.causal_cluster.Neo4jServer.Role;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Juse Ju - Millennium
+ */
+class CoreAndReadReplicasTest {
+
+	@Nested @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+	@NeedsCausalCluster(numberOfReadReplicas = 2)
+	class WithDefaultImage {
+
+		@CausalCluster
+		Neo4jCluster cluster;
+
+		@Test
+		void shouldProvideCoreAndReadReplicas() {
+
+			Set<Neo4jServer> servers = cluster.getAllServers();
+			assertCorrectNumberOfCoreAndReadReplicaServers(servers);
+		}
+	}
+
+	@Nested @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+	@NeedsCausalCluster(numberOfReadReplicas = 2, neo4jVersion = "4.1")
+	class With41 {
+
+		@CausalCluster
+		Neo4jCluster cluster;
+
+		@Test
+		void shouldProvideCoreAndReadReplicas() {
+
+			Set<Neo4jServer> servers = cluster.getAllServers();
+			assertCorrectNumberOfCoreAndReadReplicaServers(servers);
+		}
+	}
+
+	static void assertCorrectNumberOfCoreAndReadReplicaServers(Set<Neo4jServer> servers) {
+		assertThat(servers.stream().map(Neo4jServer::getRole).distinct())
+			.containsExactlyInAnyOrder(Role.CORE_SERVER, Role.REPLICA_SERVER);
+
+		Map<Role, List<Neo4jServer>> serversByType = servers.stream()
+			.collect(Collectors.groupingBy(Neo4jServer::getRole));
+		assertThat(serversByType.get(Role.CORE_SERVER)).hasSize(3);
+		assertThat(serversByType.get(Role.REPLICA_SERVER)).hasSize(2);
+
+		assertThat(servers).allSatisfy(server -> {
+			switch (server.getRole()) {
+				case CORE_SERVER:
+					assertRole(server, "LEADER", "FOLLOWER");
+					break;
+				case REPLICA_SERVER:
+					assertRole(server, "READ_REPLICA");
+					break;
+				case UNKNOWN:
+					Assertions.fail("Cluster must not contain an unknown server type");
+			}
+		});
+	}
+
+	static void assertRole(Neo4jServer server, String... expectedRoles) {
+
+		try (Driver driver = GraphDatabase
+			.driver(server.getDirectBoltUri(), AuthTokens.basic("neo4j", "password"), Config.builder().withLogging(
+				Logging.console(Level.OFF)).build());
+			Session session = driver.session()) {
+			String role = session.readTransaction(tx -> tx.run("CALL dbms.cluster.role($databaseName)",
+				Values.parameters("databaseName", "neo4j")).single().get(0).asString());
+
+			assertThat(expectedRoles).describedAs("Server of type " + server.getRole() + " had role " + role)
+				.contains(role);
+		}
+	}
+}

--- a/src/test/java/org/neo4j/junit/jupiter/causal_cluster/CoreAndReadReplicasTest.java
+++ b/src/test/java/org/neo4j/junit/jupiter/causal_cluster/CoreAndReadReplicasTest.java
@@ -37,7 +37,7 @@ import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Logging;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Values;
-import org.neo4j.junit.jupiter.causal_cluster.Neo4jServer.Role;
+import org.neo4j.junit.jupiter.causal_cluster.Neo4jServer.Type;
 
 /**
  * @author Michael J. Simons
@@ -76,16 +76,16 @@ class CoreAndReadReplicasTest {
 	}
 
 	static void assertCorrectNumberOfCoreAndReadReplicaServers(Set<Neo4jServer> servers) {
-		assertThat(servers.stream().map(Neo4jServer::getRole).distinct())
-			.containsExactlyInAnyOrder(Role.CORE_SERVER, Role.REPLICA_SERVER);
+		assertThat(servers.stream().map(Neo4jServer::getType).distinct())
+			.containsExactlyInAnyOrder(Neo4jServer.Type.CORE_SERVER, Neo4jServer.Type.REPLICA_SERVER);
 
-		Map<Role, List<Neo4jServer>> serversByType = servers.stream()
-			.collect(Collectors.groupingBy(Neo4jServer::getRole));
-		assertThat(serversByType.get(Role.CORE_SERVER)).hasSize(3);
-		assertThat(serversByType.get(Role.REPLICA_SERVER)).hasSize(2);
+		Map<Neo4jServer.Type, List<Neo4jServer>> serversByType = servers.stream()
+			.collect(Collectors.groupingBy(Neo4jServer::getType));
+		assertThat(serversByType.get(Neo4jServer.Type.CORE_SERVER)).hasSize(3);
+		assertThat(serversByType.get(Type.REPLICA_SERVER)).hasSize(2);
 
 		assertThat(servers).allSatisfy(server -> {
-			switch (server.getRole()) {
+			switch (server.getType()) {
 				case CORE_SERVER:
 					assertRole(server, "LEADER", "FOLLOWER");
 					break;
@@ -107,7 +107,7 @@ class CoreAndReadReplicasTest {
 			String role = session.readTransaction(tx -> tx.run("CALL dbms.cluster.role($databaseName)",
 				Values.parameters("databaseName", "neo4j")).single().get(0).asString());
 
-			assertThat(expectedRoles).describedAs("Server of type " + server.getRole() + " had role " + role)
+			assertThat(expectedRoles).describedAs("Server of type " + server.getType() + " had role " + role)
 				.contains(role);
 		}
 	}

--- a/src/test/java/org/neo4j/junit/jupiter/causal_cluster/LoggingTest.java
+++ b/src/test/java/org/neo4j/junit/jupiter/causal_cluster/LoggingTest.java
@@ -30,6 +30,7 @@ import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
+import org.neo4j.junit.jupiter.causal_cluster.Neo4jServer.Role;
 import org.testcontainers.containers.Neo4jContainer;
 
 /**
@@ -52,7 +53,7 @@ class LoggingTest {
 	@Test
 	void getDebugLogShouldWork() {
 
-		Neo4jServer server = new DefaultNeo4jServer(container, URI.create(container.getBoltUrl()));
+		Neo4jServer server = new DefaultNeo4jServer(container, URI.create(container.getBoltUrl()), Role.UNKNOWN);
 		String debugLogs = server.getDebugLog();
 		assertThat(debugLogs).doesNotContain("OCI runtime exec failed");
 	}
@@ -62,7 +63,8 @@ class LoggingTest {
 
 		String query = "MATCH (n) RETURN COUNT(n) as theNodeCount";
 
-		Neo4jServer server = new DefaultNeo4jServer(container, URI.create(container.getBoltUrl()));
+		Neo4jServer server = new DefaultNeo4jServer(container, URI.create(container.getBoltUrl()),
+			Role.UNKNOWN);
 		try (Driver driver = GraphDatabase.driver(server.getDirectBoltUri(), AuthTokens.none());
 			Session session = driver.session()) {
 			long nodeCount = session.readTransaction(tx -> tx.run(query).single().get(0).asLong());

--- a/src/test/java/org/neo4j/junit/jupiter/causal_cluster/LoggingTest.java
+++ b/src/test/java/org/neo4j/junit/jupiter/causal_cluster/LoggingTest.java
@@ -30,6 +30,7 @@ import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
+import org.neo4j.junit.jupiter.causal_cluster.Neo4jServer.Type;
 import org.testcontainers.containers.Neo4jContainer;
 
 /**
@@ -52,7 +53,7 @@ class LoggingTest {
 	@Test
 	void getDebugLogShouldWork() {
 
-		Neo4jServer server = new DefaultNeo4jServer(container, URI.create(container.getBoltUrl()), Neo4jServer.Type.UNKNOWN);
+		Neo4jServer server = new DefaultNeo4jServer(container, URI.create(container.getBoltUrl()), Type.CORE_SERVER);
 		String debugLogs = server.getDebugLog();
 		assertThat(debugLogs).doesNotContain("OCI runtime exec failed");
 	}
@@ -63,7 +64,7 @@ class LoggingTest {
 		String query = "MATCH (n) RETURN COUNT(n) as theNodeCount";
 
 		Neo4jServer server = new DefaultNeo4jServer(container, URI.create(container.getBoltUrl()),
-			Neo4jServer.Type.UNKNOWN);
+			Type.CORE_SERVER);
 		try (Driver driver = GraphDatabase.driver(server.getDirectBoltUri(), AuthTokens.none());
 			Session session = driver.session()) {
 			long nodeCount = session.readTransaction(tx -> tx.run(query).single().get(0).asLong());

--- a/src/test/java/org/neo4j/junit/jupiter/causal_cluster/LoggingTest.java
+++ b/src/test/java/org/neo4j/junit/jupiter/causal_cluster/LoggingTest.java
@@ -30,7 +30,6 @@ import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
-import org.neo4j.junit.jupiter.causal_cluster.Neo4jServer.Role;
 import org.testcontainers.containers.Neo4jContainer;
 
 /**
@@ -53,7 +52,7 @@ class LoggingTest {
 	@Test
 	void getDebugLogShouldWork() {
 
-		Neo4jServer server = new DefaultNeo4jServer(container, URI.create(container.getBoltUrl()), Role.UNKNOWN);
+		Neo4jServer server = new DefaultNeo4jServer(container, URI.create(container.getBoltUrl()), Neo4jServer.Type.UNKNOWN);
 		String debugLogs = server.getDebugLog();
 		assertThat(debugLogs).doesNotContain("OCI runtime exec failed");
 	}
@@ -64,7 +63,7 @@ class LoggingTest {
 		String query = "MATCH (n) RETURN COUNT(n) as theNodeCount";
 
 		Neo4jServer server = new DefaultNeo4jServer(container, URI.create(container.getBoltUrl()),
-			Role.UNKNOWN);
+			Neo4jServer.Type.UNKNOWN);
 		try (Driver driver = GraphDatabase.driver(server.getDirectBoltUri(), AuthTokens.none());
 			Session session = driver.session()) {
 			long nodeCount = session.readTransaction(tx -> tx.run(query).single().get(0).asLong());

--- a/src/test/java/org/neo4j/junit/jupiter/causal_cluster/NeedsCausalClusterTest.java
+++ b/src/test/java/org/neo4j/junit/jupiter/causal_cluster/NeedsCausalClusterTest.java
@@ -19,6 +19,7 @@
 package org.neo4j.junit.jupiter.causal_cluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -120,6 +121,19 @@ class NeedsCausalClusterTest {
 					DiscoverySelectors.selectClass(WrongCollectionSubclass1ExtensionPoint.class),
 					DiscoverySelectors.selectClass(WrongCollectionSubclass2ExtensionPoint.class),
 					DiscoverySelectors.selectClass(WrongClusterExtensionPoint.class)
+				)
+				.execute().testEvents();
+
+			assertThat(testEvents.started().stream().collect(Collectors.toList()))
+				.hasSize(0);
+		}
+
+		@Test
+		void shouldCheckNumberOfCoreServers() {
+			Events testEvents = EngineTestKit.engine(ENGINE_ID)
+				.selectors(
+					DiscoverySelectors.selectClass(InvalidNumberOfCoreServers.class),
+					DiscoverySelectors.selectClass(InvalidNumberOfReadReplicas.class)
 				)
 				.execute().testEvents();
 
@@ -478,6 +492,30 @@ class NeedsCausalClusterTest {
 		@Test
 		void aTest() {
 			assertThat(clusterUri).isNotNull();
+		}
+	}
+
+	@NeedsCausalCluster(numberOfCoreServers = 2)
+	static class InvalidNumberOfCoreServers {
+
+		@CausalCluster
+		static String clusterUri;
+
+		@Test
+		void aTest() {
+			fail("Das war wohl nichts.");
+		}
+	}
+
+	@NeedsCausalCluster(numberOfReadReplicas = -1)
+	static class InvalidNumberOfReadReplicas {
+
+		@CausalCluster
+		static String clusterUri;
+
+		@Test
+		void aTest() {
+			fail("Das war wohl nichts.");
 		}
 	}
 


### PR DESCRIPTION
We already had an attribute to configure the number of read replicas, but didn’t expose or use it. This change exposes the attribute on the `@NeedsCausalCluster` annotation and uses it accordingly.

The Neo4jServer now has an attribute indicating it’s role.

This closes #22.