### PR TITLE
Improve logging access.

### DIFF
--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultNeo4jServer.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultNeo4jServer.java
@@ -31,6 +31,17 @@ import org.testcontainers.containers.Neo4jContainer;
  */
 final class DefaultNeo4jServer implements Neo4jServer, AutoCloseable {
 
+	private enum LogFile {
+		DEBUG("debug.log"),
+		QUERY("query.log");
+
+		final String name;
+
+		LogFile(String name) {
+			this.name = name;
+		}
+	}
+
 	private final static String START_TOKEN = "Starting Neo4j.\n";
 
 	/**
@@ -48,9 +59,19 @@ final class DefaultNeo4jServer implements Neo4jServer, AutoCloseable {
 	}
 
 	@Override
-	public String getDebugLogs() {
+	public String getDebugLog() {
+		return retrieveLogFile(LogFile.DEBUG);
+	}
+
+	@Override
+	public String getQueryLog() {
+		return retrieveLogFile(LogFile.QUERY);
+	}
+
+	private String retrieveLogFile(LogFile logFile) {
+
 		try {
-			return container.execInContainer("cat /logs/debug.log").getStdout();
+			return container.execInContainer("cat", "/logs/" + logFile.name).getStdout();
 		} catch (IOException | InterruptedException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Neo4jServer.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Neo4jServer.java
@@ -31,9 +31,14 @@ import java.net.URI;
 public interface Neo4jServer {
 
 	/**
-	 * @return The complete Neo4j debug logs.
+	 * @return The complete Neo4j debug log.
 	 */
-	String getDebugLogs();
+	String getDebugLog();
+
+	/**
+	 * @return The query log.
+	 */
+	String getQueryLog();
 
 	/**
 	 * @return The complete container logs.

--- a/src/test/java/org/neo4j/junit/jupiter/causal_cluster/LoggingTest.java
+++ b/src/test/java/org/neo4j/junit/jupiter/causal_cluster/LoggingTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.junit.jupiter.causal_cluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Session;
+import org.testcontainers.containers.Neo4jContainer;
+
+/**
+ * @author Michael J. Simons
+ * @soundtrack Helge Schneider - Heart Attack No. 1
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LoggingTest {
+
+	private Neo4jContainer<?> container = new Neo4jContainer<>(
+		String.format("neo4j:%s-enterprise", CausalClusterExtension.DEFAULT_NEO4J_VERSION))
+		.withoutAuthentication()
+		.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes");
+
+	@BeforeAll
+	void startContainer() {
+		container.start();
+	}
+
+	@Test
+	void getDebugLogShouldWork() {
+
+		Neo4jServer server = new DefaultNeo4jServer(container, URI.create(container.getBoltUrl()));
+		String debugLogs = server.getDebugLog();
+		assertThat(debugLogs).doesNotContain("OCI runtime exec failed");
+	}
+
+	@Test
+	void getQueryLogShouldWork() {
+
+		String query = "MATCH (n) RETURN COUNT(n) as theNodeCount";
+
+		Neo4jServer server = new DefaultNeo4jServer(container, URI.create(container.getBoltUrl()));
+		try (Driver driver = GraphDatabase.driver(server.getDirectBoltUri(), AuthTokens.none());
+			Session session = driver.session()) {
+			long nodeCount = session.readTransaction(tx -> tx.run(query).single().get(0).asLong());
+			assertThat(nodeCount).isEqualTo(0L);
+		}
+		String queryLog = server.getQueryLog();
+		assertThat(queryLog).contains(query);
+	}
+
+	@AfterAll
+	void stopContainer() {
+		container.stop();
+	}
+
+}


### PR DESCRIPTION
This change allows for retrieving the query log. It also fixes the command that is executed in the container and closes #27. The command needs to be in separate parts, otherwise the container checks if a file `cmd somthing` exists.