### PR TITLE
[NOT READY FOR MERGE] Adds support for multiple clusters in a single test

### DIFF
--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Configuration.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Configuration.java
@@ -46,6 +46,8 @@ final class Configuration implements Serializable {
 
 	private final int pagecacheSize;
 
+	private final boolean allowMultipleClusters;
+
 	/**
 	 * Optional custom image name. Has precedence of the version number if set.
 	 */
@@ -56,7 +58,7 @@ final class Configuration implements Serializable {
 
 	Configuration(String neo4jVersion, int numberOfCoreServers, int numberOfReadReplicas, Duration startupTimeout,
 		String password, int initialHeapSize, int pagecacheSize, UnaryOperator<Neo4jContainer<?>> coreModifier,
-		UnaryOperator<Neo4jContainer<?>> readReplicaModifier, String customImageName) {
+		UnaryOperator<Neo4jContainer<?>> readReplicaModifier, String customImageName, boolean allowMultipleClusters) {
 		this.neo4jVersion = neo4jVersion;
 		this.numberOfCoreServers = numberOfCoreServers;
 		this.numberOfReadReplicas = numberOfReadReplicas;
@@ -67,6 +69,7 @@ final class Configuration implements Serializable {
 		this.coreModifier = coreModifier;
 		this.readReplicaModifier = readReplicaModifier;
 		this.customImageName = customImageName;
+		this.allowMultipleClusters = allowMultipleClusters;
 	}
 
 	String getImageName() {
@@ -122,7 +125,7 @@ final class Configuration implements Serializable {
 			this :
 			new Configuration(newNeo4jVersion, this.numberOfCoreServers, this.numberOfReadReplicas, this.startupTimeout,
 				this.password, this.initialHeapSize, this.pagecacheSize, this.coreModifier, this.readReplicaModifier,
-				this.customImageName);
+				this.customImageName, this.allowMultipleClusters);
 	}
 
 	public Configuration withNumberOfCoreServers(int newNumberOfCoreServers) {
@@ -130,7 +133,7 @@ final class Configuration implements Serializable {
 			this :
 			new Configuration(this.neo4jVersion, newNumberOfCoreServers, this.numberOfReadReplicas, this.startupTimeout,
 				this.password, this.initialHeapSize, this.pagecacheSize, this.coreModifier, this.readReplicaModifier,
-				this.customImageName);
+				this.customImageName, this.allowMultipleClusters);
 	}
 
 	public Configuration withNumberOfReadReplicas(int newNumberOfReadReplicas) {
@@ -138,7 +141,7 @@ final class Configuration implements Serializable {
 			this :
 			new Configuration(this.neo4jVersion, this.numberOfCoreServers, newNumberOfReadReplicas, this.startupTimeout,
 				this.password, this.initialHeapSize, this.pagecacheSize, this.coreModifier, this.readReplicaModifier,
-				this.customImageName);
+				this.customImageName, this.allowMultipleClusters);
 	}
 
 	public Configuration withStartupTimeout(Duration newStartupTimeout) {
@@ -146,7 +149,7 @@ final class Configuration implements Serializable {
 			this :
 			new Configuration(this.neo4jVersion, this.numberOfCoreServers, this.numberOfReadReplicas, newStartupTimeout,
 				this.password, this.initialHeapSize, this.pagecacheSize, this.coreModifier, this.readReplicaModifier,
-				this.customImageName);
+				this.customImageName, this.allowMultipleClusters);
 	}
 
 	public Configuration withPassword(String newPassword) {
@@ -154,7 +157,7 @@ final class Configuration implements Serializable {
 			this :
 			new Configuration(this.neo4jVersion, this.numberOfCoreServers, this.numberOfReadReplicas,
 				this.startupTimeout, newPassword, this.initialHeapSize, this.pagecacheSize, this.coreModifier,
-				this.readReplicaModifier, this.customImageName);
+				this.readReplicaModifier, this.customImageName, this.allowMultipleClusters);
 	}
 
 	public Configuration withInitialHeapSize(int newInitialHeapSize) {
@@ -162,7 +165,7 @@ final class Configuration implements Serializable {
 			this :
 			new Configuration(this.neo4jVersion, this.numberOfCoreServers, this.numberOfReadReplicas,
 				this.startupTimeout, this.password, newInitialHeapSize, this.pagecacheSize, coreModifier,
-				this.readReplicaModifier, this.customImageName);
+				this.readReplicaModifier, this.customImageName, this.allowMultipleClusters);
 	}
 
 	public Configuration withPagecacheSize(int newPagecacheSize) {
@@ -170,7 +173,7 @@ final class Configuration implements Serializable {
 			this :
 			new Configuration(this.neo4jVersion, this.numberOfCoreServers, this.numberOfReadReplicas,
 				this.startupTimeout, this.password, this.initialHeapSize, newPagecacheSize, this.coreModifier,
-				this.readReplicaModifier, this.customImageName);
+				this.readReplicaModifier, this.customImageName, this.allowMultipleClusters);
 	}
 
 	public Configuration withCoreModifier(UnaryOperator<Neo4jContainer<?>> newCoreModifier) {
@@ -178,14 +181,14 @@ final class Configuration implements Serializable {
 			this :
 			new Configuration(this.neo4jVersion, this.numberOfCoreServers, this.numberOfReadReplicas,
 				this.startupTimeout, this.password, this.initialHeapSize, this.pagecacheSize, newCoreModifier,
-				this.readReplicaModifier, this.customImageName);
+				this.readReplicaModifier, this.customImageName, this.allowMultipleClusters);
 	}
 
 	public Configuration withReadReplicaModifier(UnaryOperator<Neo4jContainer<?>> newReadReplicaModifier) {
 		return this.readReplicaModifier == newReadReplicaModifier ? this :
 			new Configuration(this.neo4jVersion, this.numberOfCoreServers, this.numberOfReadReplicas,
 				this.startupTimeout, this.password, this.initialHeapSize, this.pagecacheSize, this.coreModifier,
-				newReadReplicaModifier, this.customImageName);
+				newReadReplicaModifier, this.customImageName, this.allowMultipleClusters);
 	}
 
 	public Configuration withCustomImageName(String newCustomImageName) {
@@ -193,7 +196,15 @@ final class Configuration implements Serializable {
 			this :
 			new Configuration(this.neo4jVersion, this.numberOfCoreServers, this.numberOfReadReplicas,
 				this.startupTimeout, this.password, this.initialHeapSize, this.pagecacheSize, this.coreModifier,
-				this.readReplicaModifier, newCustomImageName);
+				this.readReplicaModifier, newCustomImageName, this.allowMultipleClusters);
+	}
+
+	public Configuration withAllowMultipleClusters(boolean multipleClusters) {
+		return this.allowMultipleClusters == multipleClusters ?
+			this :
+			new Configuration(this.neo4jVersion, this.numberOfCoreServers, this.numberOfReadReplicas,
+				this.startupTimeout, this.password, this.initialHeapSize, this.pagecacheSize, this.coreModifier,
+				this.readReplicaModifier, this.customImageName, multipleClusters);
 	}
 
 	public Neo4jContainer<?> applyCoreModifier(Neo4jContainer<?> core) {
@@ -210,5 +221,9 @@ final class Configuration implements Serializable {
 
 	public Neo4jContainer<?> applyReadReplicaModifier(Neo4jContainer<?> readReplicaContainer) {
 		return this.readReplicaModifier.apply(readReplicaContainer);
+	}
+
+	public boolean allowMultipleClusters() {
+		return allowMultipleClusters;
 	}
 }

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/NeedsCausalCluster.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/NeedsCausalCluster.java
@@ -65,4 +65,6 @@ public @interface NeedsCausalCluster {
 	long startupTimeOutInMillis() default CausalClusterExtension.DEFAULT_STARTUP_TIMEOUT_IN_MILLIS;
 
 	String password() default "password";
+
+	boolean createMultipleClusters() default false;
 }

--- a/src/test/java/org/neo4j/junit/jupiter/causal_cluster/MultipleClustersTest.java
+++ b/src/test/java/org/neo4j/junit/jupiter/causal_cluster/MultipleClustersTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019-2020 "Neo4j,"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.junit.jupiter.causal_cluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+@NeedsCausalCluster(numberOfReadReplicas = 1, createMultipleClusters = true)
+class MultipleClustersTest {
+	@CausalCluster
+	static Neo4jCluster clusterOne;
+
+	@CausalCluster
+	static Neo4jCluster clusterTwo;
+
+	@CausalCluster
+	static Neo4jCluster clusterThree;
+
+	private Stream<Neo4jCluster> getClusters() {
+		return Stream.of(clusterOne, clusterTwo, clusterThree);
+	}
+
+	@Test
+	void nothingIsNull() {
+		assertThat(clusterOne).isNotNull();
+		assertThat(clusterTwo).isNotNull();
+		assertThat(clusterThree).isNotNull();
+	}
+
+	@Test
+	void nothingIsTheSame() {
+		assertThat(clusterOne).isNotEqualTo(clusterTwo);
+		assertThat(clusterTwo).isNotEqualTo(clusterThree);
+		assertThat(clusterThree).isNotEqualTo(clusterOne);
+
+		assertThat(clusterOne.getAllServers()).doesNotContainAnyElementsOf(clusterTwo.getAllServers());
+		assertThat(clusterTwo.getAllServers()).doesNotContainAnyElementsOf(clusterThree.getAllServers());
+		assertThat(clusterThree.getAllServers()).doesNotContainAnyElementsOf(clusterOne.getAllServers());
+	}
+
+	@Test
+	void verifyConnectivity() {
+		// Verify connectivity
+		getClusters().flatMap(c -> c.getURIs().stream())
+			.parallel().forEach(DriverUtils::verifyConnectivity);
+	}
+
+	@Test
+	void verifyConnectivityCores() {
+		// Verify connectivity
+		getClusters().flatMap(c -> c.getAllServersOfType(Neo4jServer.Type.CORE_SERVER).stream())
+			.map(Neo4jServer::getDirectBoltUri)
+			.parallel().forEach(DriverUtils::verifyConnectivity);
+	}
+
+	@Test
+	void verifyConnectivityReadReplica() {
+		// Verify connectivity
+		getClusters().flatMap(c -> c.getAllServersOfType(Neo4jServer.Type.REPLICA_SERVER).stream())
+			.map(Neo4jServer::getDirectBoltUri)
+			.parallel().forEach(DriverUtils::verifyConnectivity);
+	}
+}


### PR DESCRIPTION
more tests need to be added:
 - fail explicitly if convenience fields are used with multiple clusters
 - add a test to assert the order of injection of CausalCluster annotated fields (should be alphabetical by field name)