### PR TITLE
add a load balanced address for clusters

### DIFF
--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/ClusterFactory.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/ClusterFactory.java
@@ -43,11 +43,14 @@ import org.testcontainers.containers.SocatContainer;
  */
 final class ClusterFactory {
 
+	static final int BALANCED_PORT = 8888;
 	private static final int DEFAULT_BOLT_PORT = 7687;
+	private static final String balancedAddress = "neo4j.balanced";
 	public static final int MINIMUM_NUMBER_OF_CORE_SERVERS_REQUIRED = 3;
 	public static final int MINIMUM_NUMBER_OF_REPLICA_SERVERS_REQUIRED = 0;
 
 	private final Configuration configuration;
+
 
 	private SocatContainer boltProxy;
 
@@ -79,6 +82,7 @@ final class ClusterFactory {
 
 		// Prepare proxy to enter the cluster
 		boltProxy = new SocatContainer().withNetwork(onNetwork);
+		boltProxy.withTarget(BALANCED_PORT, balancedAddress, DEFAULT_BOLT_PORT);
 		iterateCoreServers().forEach(member -> boltProxy
 			.withTarget(member.getKey(), member.getValue(), DEFAULT_BOLT_PORT));
 		iterateReplicaServers().forEach(member -> boltProxy
@@ -207,7 +211,7 @@ final class ClusterFactory {
 			.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
 			.withAdminPassword(configuration.getPassword())
 			.withNetwork(network)
-			.withNetworkAliases(alias)
+			.withNetworkAliases(alias, balancedAddress)
 			.withCreateContainerCmdModifier(cmd -> cmd.withHostName(alias))
 			.withNeo4jConfig("dbms.memory.pagecache.size", configuration.getPagecacheSize() + "M")
 			.withNeo4jConfig("dbms.memory.heap.initial_size", configuration.getInitialHeapSize() + "M")

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultNeo4jCluster.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/DefaultNeo4jCluster.java
@@ -18,6 +18,7 @@
  */
 package org.neo4j.junit.jupiter.causal_cluster;
 
+import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -82,6 +83,15 @@ final class DefaultNeo4jCluster implements Neo4jCluster, CloseableResource {
 
 		boltProxy.close();
 		clusterServers.forEach(DefaultNeo4jServer::close);
+	}
+
+	@Override
+	public URI getBalancedURI() {
+		return URI.create(String.format(
+			"neo4j://%s:%d",
+			boltProxy.getContainerIpAddress(),
+			boltProxy.getMappedPort(ClusterFactory.BALANCED_PORT)
+		));
 	}
 
 	@Override

--- a/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Neo4jCluster.java
+++ b/src/main/java/org/neo4j/junit/jupiter/causal_cluster/Neo4jCluster.java
@@ -63,6 +63,11 @@ public interface Neo4jCluster {
 	}
 
 	/**
+	 * @return A URIs that is load balanced over all members of this cluster
+	 */
+	URI getBalancedURI();
+
+	/**
 	 * @return The Neo4j servers contained by this cluster.
 	 */
 	Set<Neo4jServer> getAllServers();


### PR DESCRIPTION
This mirrors some customer architectures.

I wonder about adding some options here though e.g.

A) an address balanced over all cores _and_ read replicas (what this does)
B) an address balanced over all cores
C) an address balanced over all read replicas